### PR TITLE
Ksh/empty queue problems

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,12 +92,16 @@ schedule.prototype._start = function () {
 
   peek.first(self.db, function (err, key, task) {
     // no tasks found
-    if (err) return;
+    if (err) {
+      if (self.timeout) clearTimeout(self.timeout.id);
+      self.timeout = null;
+      return;
+    }
 
     // we inserted the task so we can trust it's valid json
     task = JSON.parse(task);
 
-    var ts = key.split('!')[0];
+    var ts = parseInt(key.split('!')[0], 10);
     var job = self.jobs[task.job];
     var payload = task.payload;
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "json-stringify-safe": "~5.0.0"
   },
   "devDependencies": {
-    "tap": "~0.4.4",
+    "level": "^1.1.0",
     "rimraf": "~2.1.4",
-    "level": "~0.13.0"
+    "tap": "~0.4.4"
   },
   "keywords": [
     "schedule",

--- a/test/test.js
+++ b/test/test.js
@@ -77,6 +77,23 @@ test('async w/ payload', function (t, db) {
     .run('async', 'foo', Date.now());
 });
 
+test('async w/ queued async', function (t, db) {
+  var sch = Schedule(db);
+  sch
+    .job('async', function (payload, done) {
+      done();
+      // This has to execute after the done() has deleted the previous task.
+      setTimeout(function() {
+        sch.run('async2', 'foo', Date.now())
+      }, 1000);
+    })
+    .job('async2', function(payload, done) {
+      done();
+      t.end();
+    })
+    .run('async', 'foo', Date.now());
+});
+
 test('error: job not found', function (t, db) {
   Schedule(db)
     .on('error', function (err) {


### PR DESCRIPTION
Hi again!

I found two bugs, hopefully fixed them. The first was that the timestamp split from the string key was still a string, so `>` comparisons wouldn't necessarily be accurate at the end of the `run` method.

The other was more insidious. If you scheduled a task, allowed it to execute, then scheduled another task, the subsequent task would never be executed due to the `_start` method never clearing the previous timeout information.

I also added a test for this case, and bumped the `level` dependency because without doing so I couldn't even `npm install` on using a recent version of iojs.

Please let me know if there's something you'd like changed with this PR!