### PR TITLE
fix scheduling! use ts from value, not key

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
+    "debug": "^2.2.0",
     "json-stringify-safe": "~5.0.0",
     "level-peek": "~1.0.6",
     "lexicographic-integer": "^1.1.0"


### PR DESCRIPTION
Hello again!

Even though `lexicographic-integer` creates hexadecimal values, they don't parse back into the original value:

```
> parseInt('ff080a7025c4ba50', 16)
18376949756271573000
```

So scheduling was completely broken, meaning any queued tasks were executed immediately (using `NaN` as a timeout duration).

I also added in the `debug` package for some insight into what the package is doing. If that's not ok, feel free to just take my one-line change separately :)

Thanks!